### PR TITLE
Include standard libs for modernized cpp

### DIFF
--- a/ungtc.cpp
+++ b/ungtc.cpp
@@ -17,7 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
+#include <cstring>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <vector>


### PR DESCRIPTION
On modern cpp uint32_t and operations like memset and strncpy are not available by default. Including cstdint and cstring solves this.